### PR TITLE
feat: allow clearing API key override

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -52,7 +52,7 @@ jobs:
           echo "Preview version: ${PREVIEW_VERSION}"
 
       - name: Build release APK
-        run: flutter build apk --release --dart-define=DEFAULT_OPENROUTER_API_KEY=${{ secrets.DEFAULT_OPENROUTER_API_KEY }}
+        run: flutter build apk --release
 
       - name: Upload APK
         id: upload-apk

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -52,7 +52,7 @@ jobs:
           echo "Preview version: ${PREVIEW_VERSION}"
 
       - name: Build release APK
-        run: flutter build apk --release
+        run: flutter build apk --release --dart-define=DEFAULT_OPENROUTER_API_KEY=${{ secrets.DEFAULT_OPENROUTER_API_KEY }}
 
       - name: Upload APK
         id: upload-apk

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -30,6 +30,11 @@ class SettingsService {
     await _prefs.setString(_openRouterKeyKey, key);
   }
 
+  bool hasOpenRouterApiKeyOverride() {
+    final stored = _prefs.getString(_openRouterKeyKey);
+    return stored != null && stored.isNotEmpty;
+  }
+
   Future<void> clearOpenRouterApiKey() async {
     await _prefs.remove(_openRouterKeyKey);
   }

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -248,6 +248,7 @@ class _ApiKeySection extends StatefulWidget {
 class _ApiKeySectionState extends State<_ApiKeySection> {
   late SettingsService _settingsService;
   bool _hasApiKey = false;
+  bool _hasApiKeyOverride = false;
 
   @override
   void initState() {
@@ -260,7 +261,24 @@ class _ApiKeySectionState extends State<_ApiKeySection> {
     setState(() {
       final key = _settingsService.getOpenRouterApiKey();
       _hasApiKey = key != null && key.isNotEmpty;
+      _hasApiKeyOverride = _settingsService.hasOpenRouterApiKeyOverride();
     });
+  }
+
+  Future<void> _clearApiKeyOverride() async {
+    try {
+      await _settingsService.clearOpenRouterApiKey();
+      if (!mounted) return;
+      _checkApiKeyStatus();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('API key override cleared')),
+      );
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not clear the API key override')),
+      );
+    }
   }
 
   void _showApiKeyDialog() {
@@ -317,7 +335,11 @@ class _ApiKeySectionState extends State<_ApiKeySection> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    _hasApiKey ? '✓ Configured' : '✗ Not configured',
+                    _hasApiKeyOverride
+                        ? '✓ Using custom key'
+                        : _hasApiKey
+                        ? '✓ Using built-in key'
+                        : '✗ Not configured',
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: _hasApiKey ? Colors.green : Colors.red,
                     ),
@@ -331,6 +353,17 @@ class _ApiKeySectionState extends State<_ApiKeySection> {
             ),
           ],
         ),
+        if (_hasApiKeyOverride) ...[
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: _clearApiKeyOverride,
+              icon: const Icon(Icons.restore),
+              label: const Text('Use Built-in Key'),
+            ),
+          ),
+        ],
         const SizedBox(height: 12),
         RichText(
           text: TextSpan(

--- a/test/settings_service_test.dart
+++ b/test/settings_service_test.dart
@@ -1,0 +1,21 @@
+import 'package:daily_manna/services/settings_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('clearing the API key removes the custom override', () async {
+    SharedPreferences.setMockInitialValues({});
+    final settings = SettingsService();
+    await settings.init();
+
+    await settings.setOpenRouterApiKey('custom-key');
+    expect(settings.hasOpenRouterApiKeyOverride(), isTrue);
+    expect(settings.getOpenRouterApiKey(), 'custom-key');
+
+    await settings.clearOpenRouterApiKey();
+    expect(settings.hasOpenRouterApiKeyOverride(), isFalse);
+    expect(settings.getOpenRouterApiKey(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- distinguish custom and built-in OpenRouter API key states in Settings
- add an action to clear a custom override and return to the built-in key
- cover API key override removal in SettingsService tests

## Testing
- flutter analyze
- flutter test